### PR TITLE
Fixes model data download location. Closes #42

### DIFF
--- a/models/coco/download_models.sh
+++ b/models/coco/download_models.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-curl -O http://datasets.d2.mpi-inf.mpg.de/deepercut-models-tensorflow/coco-resnet-101.data-00000-of-00001
-curl -O http://datasets.d2.mpi-inf.mpg.de/deepercut-models-tensorflow/coco-resnet-101.meta
-curl -O http://datasets.d2.mpi-inf.mpg.de/deepercut-models-tensorflow/coco-resnet-101.index
+curl -O -L https://datasets.d2.mpi-inf.mpg.de/deepercut-models-tensorflow/coco-resnet-101.data-00000-of-00001
+curl -O -L https://datasets.d2.mpi-inf.mpg.de/deepercut-models-tensorflow/coco-resnet-101.meta
+curl -O -L https://datasets.d2.mpi-inf.mpg.de/deepercut-models-tensorflow/coco-resnet-101.index
 
-curl -O http://datasets.d2.mpi-inf.mpg.de/deepercut-models-tensorflow/pairwise_coco.tar.gz
+curl -O -L https://datasets.d2.mpi-inf.mpg.de/deepercut-models-tensorflow/pairwise_coco.tar.gz
 tar xvzf pairwise_coco.tar.gz

--- a/models/mpii/download_models.sh
+++ b/models/mpii/download_models.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-curl -O http://datasets.d2.mpi-inf.mpg.de/deepercut-models-tensorflow/mpii-single-resnet-101.data-00000-of-00001
-curl -O http://datasets.d2.mpi-inf.mpg.de/deepercut-models-tensorflow/mpii-single-resnet-101.meta
-curl -O http://datasets.d2.mpi-inf.mpg.de/deepercut-models-tensorflow/mpii-single-resnet-101.index
+curl -O -L https://datasets.d2.mpi-inf.mpg.de/deepercut-models-tensorflow/mpii-single-resnet-101.data-00000-of-00001
+curl -O -L https://datasets.d2.mpi-inf.mpg.de/deepercut-models-tensorflow/mpii-single-resnet-101.meta
+curl -O -L https://datasets.d2.mpi-inf.mpg.de/deepercut-models-tensorflow/mpii-single-resnet-101.index


### PR DESCRIPTION
Model data location changed to https server, for future relocation
option -L (follow moves) has been added to the curl command.