### PR TITLE
Fix issue appearing when upgrading to tensorflow 1.4

### DIFF
--- a/nnet/pose_net.py
+++ b/nnet/pose_net.py
@@ -46,9 +46,8 @@ class PoseNet:
                            dtype=tf.float32, shape=[1, 1, 1, 3], name='img_mean')
         im_centered = inputs - mean
 
-        with slim.arg_scope(resnet_v1.resnet_arg_scope(False)):
-            net, end_points = net_fun(im_centered,
-                                      global_pool=False, output_stride=16)
+        with slim.arg_scope(resnet_v1.resnet_arg_scope()):
+            net, end_points = net_fun(im_centered, global_pool=False, output_stride=16, is_training=False)
 
         return net, end_points
 


### PR DESCRIPTION
This fixes #49 which appears when you upgrade to tensorflow 1.4 by the use of a removed feature. is_training now must be specified to the model instead of the arg_scope.